### PR TITLE
Fix broken link to documentation in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-More information about NVelocity can be found at [docs/README.md](docs/README.md)
+More information about NVelocity can be found at [docs/nvelocity.md](docs/nvelocity.md)


### PR DESCRIPTION
Belatedly noticed that the documentation link in `README.md` points to a non-existing file... let's fix that minor glitch. :)