### PR TITLE
Added strong name to directive properties.

### DIFF
--- a/src/NVelocity/Runtime/Defaults/directive.properties
+++ b/src/NVelocity/Runtime/Defaults/directive.properties
@@ -1,6 +1,6 @@
-directive.1=NVelocity.Runtime.Directive.Foreach\,NVelocity
-directive.2=NVelocity.Runtime.Directive.Include\,NVelocity
-directive.3=NVelocity.Runtime.Directive.Parse\,NVelocity
-directive.4=NVelocity.Runtime.Directive.Macro\,NVelocity
-directive.5=NVelocity.Runtime.Directive.Literal\,NVelocity
-directive.6=NVelocity.Runtime.Directive.Break\,NVelocity
+directive.1=NVelocity.Runtime.Directive.Foreach\,NVelocity\,Version=1.0.0.0\,Culture=neutral\,PublicKeyToken=407dd0808d44fbdc
+directive.2=NVelocity.Runtime.Directive.Include\,NVelocity\,Version=1.0.0.0\,Culture=neutral\,PublicKeyToken=407dd0808d44fbdc
+directive.3=NVelocity.Runtime.Directive.Parse\,NVelocity\,Version=1.0.0.0\,Culture=neutral\,PublicKeyToken=407dd0808d44fbdc
+directive.4=NVelocity.Runtime.Directive.Macro\,NVelocity\,Version=1.0.0.0\,Culture=neutral\,PublicKeyToken=407dd0808d44fbdc
+directive.5=NVelocity.Runtime.Directive.Literal\,NVelocity\,Version=1.0.0.0\,Culture=neutral\,PublicKeyToken=407dd0808d44fbdc
+directive.6=NVelocity.Runtime.Directive.Break\,NVelocity\,Version=1.0.0.0\,Culture=neutral\,PublicKeyToken=407dd0808d44fbdc


### PR DESCRIPTION
We have a solution that installs NVelocity assembly to GAC. But the directive manager tries to load types dynamically without strong name.

Added strong name to directive properties so loading from GAC works.